### PR TITLE
Fix failed to add ruleset and build warning

### DIFF
--- a/Hitokori/Mods/HitokoriModAuto.cs
+++ b/Hitokori/Mods/HitokoriModAuto.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Graphics.Sprites;
+﻿using System.Collections.Generic;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Hitokori.Beatmaps;
@@ -78,11 +79,14 @@ namespace osu.Game.Rulesets.Hitokori.Mods {
 			"Merg"
 		};
 
-		public override Score CreateReplayScore ( IBeatmap beatmap ) {
-			return new Score {
-				ScoreInfo = new ScoreInfo { User = new User { Username = BotNames.Random() } },
-				Replay = new HitokoriAutoGenerator( beatmap as HitokoriBeatmap ).Generate()
+		public override Score CreateReplayScore ( IBeatmap beatmap, IReadOnlyList<Mod> mods)
+		{
+			var score = new Score
+			{
+				ScoreInfo = new ScoreInfo {User = new User {Username = BotNames.Random()}},
+				Replay = new HitokoriAutoGenerator(beatmap as HitokoriBeatmap).Generate()
 			};
+			return score;
 		}
 	}
 }

--- a/Hitokori/Settings/HitokoriSettingsManager.cs
+++ b/Hitokori/Settings/HitokoriSettingsManager.cs
@@ -13,22 +13,22 @@ namespace osu.Game.Rulesets.Hitokori.Settings {
 		public HitokoriSettingsManager ( SettingsStore settings, RulesetInfo ruleset, int? variant = null ) : base( settings, ruleset, variant ) { }
 
 		protected override void InitialiseDefaults () {
-			Set( HitokoriSetting.CameraSpeed, 1, 1 / 2d, 3, 0.1 );
-			Set( HitokoriSetting.RingOpacity, 0.15, 0, 1, 0.01 );
-			Set( HitokoriSetting.RingDashStyle, DashStyle.Dashed );
-			Set( HitokoriSetting.ConnectorWidth, 1, 0.4, 4 );
-			Set( HitokoriSetting.HoldConnectorWidth, 1, 0.2, 2 );
-			Set( HitokoriSetting.ShowSpeeedChange, true );
+			SetDefault( HitokoriSetting.CameraSpeed, 1, 1 / 2d, 3, 0.1 );
+			SetDefault( HitokoriSetting.RingOpacity, 0.15, 0, 1, 0.01 );
+			SetDefault( HitokoriSetting.RingDashStyle, DashStyle.Dashed );
+			SetDefault( HitokoriSetting.ConnectorWidth, 1, 0.4, 4 );
+			SetDefault( HitokoriSetting.HoldConnectorWidth, 1, 0.2, 2 );
+			SetDefault( HitokoriSetting.ShowSpeeedChange, true );
 
-			Set( HitokoriSetting._HiColorR, 1f, 0, 1 );
-			Set( HitokoriSetting._HiColorG, 0f, 0, 1 );
-			Set( HitokoriSetting._HiColorB, 0f, 0, 1 );
-			Set( HitokoriSetting._KoriColorR, 0f, 0, 1 );
-			Set( HitokoriSetting._KoriColorG, 0f, 0, 1 );
-			Set( HitokoriSetting._KoriColorB, 1f, 0, 1 );
-			Set( HitokoriSetting._GreenBitchColorR, 0f, 0, 1 );
-			Set( HitokoriSetting._GreenBitchColorG, Color4.Green.G, 0, 1 );
-			Set( HitokoriSetting._GreenBitchColorB, 0f, 0, 1 );
+			SetDefault( HitokoriSetting._HiColorR, 1f, 0, 1 );
+			SetDefault( HitokoriSetting._HiColorG, 0f, 0, 1 );
+			SetDefault( HitokoriSetting._HiColorB, 0f, 0, 1 );
+			SetDefault( HitokoriSetting._KoriColorR, 0f, 0, 1 );
+			SetDefault( HitokoriSetting._KoriColorG, 0f, 0, 1 );
+			SetDefault( HitokoriSetting._KoriColorB, 1f, 0, 1 );
+			SetDefault( HitokoriSetting._GreenBitchColorR, 0f, 0, 1 );
+			SetDefault( HitokoriSetting._GreenBitchColorG, Color4.Green.G, 0, 1 );
+			SetDefault( HitokoriSetting._GreenBitchColorB, 0f, 0, 1 );
 
 			GetOriginalBindable<float>( HitokoriSetting._HiColorR ).ValueChanged += v => HiColor.Value = new Color4( v.NewValue, HiColor.Value.G, HiColor.Value.B, 1 );
 			GetOriginalBindable<float>( HitokoriSetting._HiColorG ).ValueChanged += v => HiColor.Value = new Color4( HiColor.Value.R, v.NewValue, HiColor.Value.B, 1 );

--- a/Hitokori/osu.Game.Rulesets.Hitokori.csproj
+++ b/Hitokori/osu.Game.Rulesets.Hitokori.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2021.416.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.424.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request is target to fix #21 and fix these warning during the build.

```
osu.Game.Rulesets.Hitokori
  HitokoriModAuto.cs(81, 25): [CS0672] Member 'HitokoriModAuto.CreateReplayScore(IBeatmap)' overrides obsolete member 'ModAutoplay.CreateReplayScore(IBeatmap)'. Add the Obsolete attribute to 'HitokoriModAuto.CreateReplayScore(IBeatmap)'.
  HitokoriSettingsManager.cs(16, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, double, double?, double?, double?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(17, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, double, double?, double?, double?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(18, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set<TValue>(HitokoriSetting, TValue)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(19, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, double, double?, double?, double?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(20, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, double, double?, double?, double?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(21, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, bool)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(23, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(24, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(25, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(26, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(27, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(28, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(29, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(30, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
  HitokoriSettingsManager.cs(31, 4): [CS0618] 'ConfigManager<HitokoriSetting>.Set(HitokoriSetting, float, float?, float?, float?)' is obsolete: 'In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.'
```